### PR TITLE
ofxKinectNuiPlayer wasn't rendering skeletons correctly.  The skeleton p...

### DIFF
--- a/src/ofxKinectNuiPlayer.cpp
+++ b/src/ofxKinectNuiPlayer.cpp
@@ -860,8 +860,8 @@ float ofxKinectNuiPlayer::getAudioAngleConfidence() {
 	@return	Scaled skeleton point
 */
 ofPoint ofxKinectNuiPlayer::calcScaledSkeletonPoint(const ofPoint& skeletonPoint, float width, float height){
-	float px = min((skeletonPoint.x * width) + 0.5f, (float)width);
-	float py = min((skeletonPoint.y * height) + 0.5f, (float)height);
+	float px = ofMap(skeletonPoint.x, 0, depthWidth, 0, width);
+	float py = ofMap(skeletonPoint.y+15, 0, depthHeight, 0, height); // +15 - the skeletons are a little high
 	return ofPoint(px, py);
 }
 


### PR DESCRIPTION
...oints are recorded un-normalized, so they need to be normalized and then adjusted to width/height.  Plus, I don't think the min() are needed because the skeleton points often go outside of the resolution of the depth image, and this is a desired behavior.
