### PR TITLE
Fixed bug where the skeletons were not aligned with the RGB in cases where scale != 1 and x,y != 0

### DIFF
--- a/src/ofxKinectNui.cpp
+++ b/src/ofxKinectNui.cpp
@@ -560,8 +560,9 @@ void ofxKinectNui::drawSkeleton(){
 */
 void ofxKinectNui::drawSkeleton(float x, float y, float w, float h){
 	ofPushMatrix();
-	ofScale(1.0f/(float)depthWidth * w, 1.0f/(float)depthHeight * h);
 	ofTranslate(x, y);
+	ofScale(1.0f/(float)depthWidth * w, 1.0f/(float)depthHeight * h);
+	
 	drawSkeleton();
 	ofPopMatrix();
 }


### PR DESCRIPTION
...GB in cases where scale != 1 and x,y != 0
